### PR TITLE
Expand command execution interval so the stored procedures would fit into it. 

### DIFF
--- a/HfsChargesContainer/Program.cs
+++ b/HfsChargesContainer/Program.cs
@@ -1,4 +1,4 @@
-﻿using HfsChargesContainer;
+using HfsChargesContainer;
 
 Console.WriteLine("Application started!\nConfiguring the Start up!");
 
@@ -8,7 +8,5 @@ var entryPoint = new Startup()
 
 Console.WriteLine("Ready to Run!");
 await entryPoint.Run();
-
-Console.Error.WriteLine("Test Error Log Behaviour");
 
 Console.WriteLine("Application finished!");

--- a/HfsChargesContainer/Startup.cs
+++ b/HfsChargesContainer/Startup.cs
@@ -72,7 +72,9 @@ namespace HfsChargesContainer
             services.AddDbContext<DatabaseContext>(opt =>
                 opt.UseSqlServer(hfsDbConnectionString, sqlOptions =>
                 {
-                    sqlOptions.CommandTimeout(360);
+                    // The '0' for infinite timeout is not allowed even though documentation
+                    // says the opposite. So setting it to 2 hours instead. 
+                    sqlOptions.CommandTimeout(7200);
                 })
             );
         }


### PR DESCRIPTION
# What:
 - Increased command timeout to 2 hours. _(Half would suffice, but why keep it at the edge of breaking?)_

# Why:
 - The Charges Ingest run currently takes ~61 minutes to complete. Some stored procedures are quite lengthy, as such, a long command timeout is needed.

# Notes:
 - Cannot "not set" the command timeout, because it defaults to 30 seconds, which is too little.
 - Cannot "set to 0" because upon doing so an exception is raised. The documentation of the command timeout does not match the reality. 