### PR TITLE
Sns notification alerts

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -6,7 +6,9 @@ DB_PASSWORD=
 GOOGLE_API_KEY=
 CHARGES_BATCH_YEARS=
 BATCH_SIZE=
+
+# Keep as 'local' unless you want to trigger SNS topic email sending functionality.
 ENVIRONMENT=local
 
-# Do not set this unless you indent to test a notication alert email
+# Do not set this unless you intend to test a notication alert email
 SNS_TOPIC_ARN=

--- a/.env.sample
+++ b/.env.sample
@@ -6,3 +6,7 @@ DB_PASSWORD=
 GOOGLE_API_KEY=
 CHARGES_BATCH_YEARS=
 BATCH_SIZE=
+ENVIRONMENT=local
+
+# Do not set this unless you indent to test a notication alert email
+SNS_TOPIC_ARN=

--- a/HfsChargesContainer/Helpers/EmailAlertsHandler.cs
+++ b/HfsChargesContainer/Helpers/EmailAlertsHandler.cs
@@ -1,0 +1,37 @@
+using Amazon;
+using Amazon.SimpleNotificationService;
+using Amazon.SimpleNotificationService.Model;
+
+namespace HfsChargesContainer.Helpers
+{
+    public static class EmailAlertsHandler
+    {
+        private static readonly string _topicArn;
+        private static readonly AmazonSimpleNotificationServiceClient _asnsClient;
+
+        static EmailAlertsHandler()
+        {
+            _topicArn = Environment.GetEnvironmentVariable("SNS_TOPIC_ARN")
+                ?? throw new ArgumentNullException(nameof(_topicArn));
+
+            var clientConfig = new AmazonSimpleNotificationServiceConfig()
+            {
+                RegionEndpoint = RegionEndpoint.EUWest2,
+            };
+
+            _asnsClient = new AmazonSimpleNotificationServiceClient(clientConfig);
+        }
+
+        public static async Task SendEmailAlert(Exception ex, string environment)
+        {
+            var request = new PublishRequest
+            {
+                TopicArn = _topicArn,
+                Message = ex.Message,
+                Subject = $"[Warning!] Charges Ingest nightly process failure! [environment: {environment}]"
+            };
+
+            await _asnsClient.PublishAsync(request).ConfigureAwait(false);
+        }
+    }
+}

--- a/HfsChargesContainer/Helpers/EmailAlertsHandler.cs
+++ b/HfsChargesContainer/Helpers/EmailAlertsHandler.cs
@@ -50,7 +50,7 @@ namespace HfsChargesContainer.Helpers
             {
                 TopicArn = _topicArn,
                 Message = ex.Message,
-                Subject = $"[Warning!] Charges Ingest nightly process failure! [environment: {environment}]"
+                Subject = $"[Error!] Charges Ingest nightly process failure! [environment: {environment}]"
             };
 
             await _asnsClient.PublishAsync(request).ConfigureAwait(false);

--- a/HfsChargesContainer/HfsChargesContainer.csproj
+++ b/HfsChargesContainer/HfsChargesContainer.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.200.19" />
     <PackageReference Include="EFCore.BulkExtensions" Version="7.1.5" />
     <PackageReference Include="Google.Apis.Sheets.v4" Version="1.61.0.3113" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.9" />

--- a/HfsChargesContainer/Program.cs
+++ b/HfsChargesContainer/Program.cs
@@ -18,16 +18,20 @@ catch (Exception ex)
 {
     LoggingHandler.LogError("An exception was caught at the program root level.");
 
-    string environment = Environment.GetEnvironmentVariable("ENVIRONMENT")
-        ?? throw new ArgumentNullException(nameof(environment));
+    string? environment = Environment.GetEnvironmentVariable("ENVIRONMENT");
+
+    if (environment is null)
+        LoggingHandler.LogError($"Unset environment variable: '${nameof(environment)}'!");
 
     if (environment == "local")
         throw;
 
     LoggingHandler.LogError("Attempting to send out an SNS Nofication alert.");
 
-    await EmailAlertsHandler.SendEmailAlert(ex, environment);
+    await EmailAlertsHandler.TrySendEmailAlert(ex, environment);
 
-    // Throw to get the exception logged with the stack trace.
+    LoggingHandler.LogError("\nApplication exception:\n");
+
+    // Throw to get exception logged.
     throw;
 }

--- a/HfsChargesContainer/Program.cs
+++ b/HfsChargesContainer/Program.cs
@@ -1,7 +1,4 @@
-﻿using Amazon;
-using Amazon.SimpleNotificationService;
-using Amazon.SimpleNotificationService.Model;
-using HfsChargesContainer;
+﻿using HfsChargesContainer;
 using HfsChargesContainer.Helpers;
 
 try
@@ -21,31 +18,16 @@ catch (Exception ex)
 {
     LoggingHandler.LogError("An exception was caught at the program root level.");
 
-    string environment = Environment.GetEnvironmentVariable("ENVIRONMENT") ?? throw new ArgumentNullException(nameof(environment));
+    string environment = Environment.GetEnvironmentVariable("ENVIRONMENT")
+        ?? throw new ArgumentNullException(nameof(environment));
 
     if (environment == "local")
         throw;
 
     LoggingHandler.LogError("Attempting to send out an SNS Nofication alert.");
 
-    var clientConfig = new AmazonSimpleNotificationServiceConfig()
-    {
-        RegionEndpoint = RegionEndpoint.EUWest2,
-    };
+    await EmailAlertsHandler.SendEmailAlert(ex, environment);
 
-    var asnsClient = new AmazonSimpleNotificationServiceClient(clientConfig);
-
-    string topicArn = Environment.GetEnvironmentVariable("SNS_TOPIC_ARN") ?? throw new ArgumentNullException(nameof(topicArn));
-
-    var request = new PublishRequest
-    {
-        TopicArn = topicArn,
-        Message = ex.Message,
-        Subject = $"[Warning!] Charges Ingest nightly process failure! [environment: {environment}]"
-    };
-
-    await asnsClient.PublishAsync(request).ConfigureAwait(false);
-
-    // Throw again to get the exception logged with the stack trace.
+    // Throw to get the exception logged with the stack trace.
     throw;
 }

--- a/HfsChargesContainer/Program.cs
+++ b/HfsChargesContainer/Program.cs
@@ -3,16 +3,16 @@ using HfsChargesContainer.Helpers;
 
 try
 {
-    Console.WriteLine("Application started!\nConfiguring the Start up!");
+    LoggingHandler.LogError("Application started!\nConfiguring the Start up!");
 
     var entryPoint = new Startup()
         .ConfigureServices()
         .Build<ProcessEntryPoint>();
 
-    Console.WriteLine("Ready to Run!");
+    LoggingHandler.LogError("Ready to Run!");
     await entryPoint.Run();
 
-    Console.WriteLine("Application finished!");
+    LoggingHandler.LogError("Application finished!");
 }
 catch (Exception ex)
 {

--- a/HfsChargesContainer/Program.cs
+++ b/HfsChargesContainer/Program.cs
@@ -1,12 +1,51 @@
+﻿using Amazon;
+using Amazon.SimpleNotificationService;
+using Amazon.SimpleNotificationService.Model;
 using HfsChargesContainer;
+using HfsChargesContainer.Helpers;
 
-Console.WriteLine("Application started!\nConfiguring the Start up!");
+try
+{
+    Console.WriteLine("Application started!\nConfiguring the Start up!");
 
-var entryPoint = new Startup()
-    .ConfigureServices()
-    .Build<ProcessEntryPoint>();
+    var entryPoint = new Startup()
+        .ConfigureServices()
+        .Build<ProcessEntryPoint>();
 
-Console.WriteLine("Ready to Run!");
-await entryPoint.Run();
+    Console.WriteLine("Ready to Run!");
+    await entryPoint.Run();
 
-Console.WriteLine("Application finished!");
+    Console.WriteLine("Application finished!");
+}
+catch (Exception ex)
+{
+    LoggingHandler.LogError("An exception was caught at the program root level.");
+
+    string environment = Environment.GetEnvironmentVariable("ENVIRONMENT") ?? throw new ArgumentNullException(nameof(environment));
+
+    if (environment == "local")
+        throw;
+
+    LoggingHandler.LogError("Attempting to send out an SNS Nofication alert.");
+
+    var clientConfig = new AmazonSimpleNotificationServiceConfig()
+    {
+        RegionEndpoint = RegionEndpoint.EUWest2,
+    };
+
+    var asnsClient = new AmazonSimpleNotificationServiceClient(clientConfig);
+
+    string topicArn = Environment.GetEnvironmentVariable("SNS_TOPIC_ARN") ?? throw new ArgumentNullException(nameof(topicArn));
+
+    var request = new PublishRequest
+    {
+        TopicArn = topicArn,
+        Message = ex.Message,
+        Subject = $"[Warning!] Charges Ingest nightly process failure! [environment: {environment}]"
+    };
+
+    await asnsClient.PublishAsync(request).ConfigureAwait(false);
+
+    // Throw again to get the exception logged with the stack trace.
+    throw;
+}


### PR DESCRIPTION
# What:
 - Added basic functionality to publish an 'exception' message to SNS Topic that is configured to send the developers an Email when something goes wrong.

# Why:
 - Silent nightly process failures reduce our team's response time when it comes to resolving an unfinished/failed nightly run. As such, we have configured a  functionality that sends out emails upon process failure.

# Notes:
 - With lambda hosting or even an EC2 API hosting no C# code would be necessary as we could rely entirely on the CloudWatch alarm metrics to trigger the email sending. However, in this particular case, we're not using lambda _(can't monitor for failure exit codes)_, and we don't have an API _(can't monitor for Http response codes)_, which leaves us with no CW metrics to draw upon. As such, we're adding this code _(this PR)_ to trigger the email sending manually.
 - This manual email send trigger also has a benefit of us having full control over the email's Subject & partial control over its body contents _(which is great)_.
 - Using a static EmailAlertHandler class to simplify what's going on within the Program.
 - The exceptions related to SNS feature get suppressed from getting throw deliberately & are logged instead so that they wouldn't stamp over the initial exception that was supposed to be reported via SNS.