### PR TITLE
Ssm parameter store vars

### DIFF
--- a/HfsChargesContainer.Tests/Helpers/RuntimeEnvVarsHandlerTests.cs
+++ b/HfsChargesContainer.Tests/Helpers/RuntimeEnvVarsHandlerTests.cs
@@ -20,7 +20,7 @@ namespace HfsChargesContainer.Tests.Helpers
 
         public RuntimeEnvVarsHandlerTests()
         {
-            _ssmToAppKeyLookup = new ()
+            _ssmToAppKeyLookup = new()
             {
                 { "/area-of-service/environment/db-host", "DB_HOST" },
                 { "/nightly-job/environment/google-api-key", "GOOGLE_API_KEY" },
@@ -66,7 +66,8 @@ namespace HfsChargesContainer.Tests.Helpers
             // Clear the environment
             appKeys.ForEach(ak => Environment.SetEnvironmentVariable(ak, null));
 
-            var expectedSSMParams = ssmKeys.Select(sk => new Parameter() {
+            var expectedSSMParams = ssmKeys.Select(sk => new Parameter()
+            {
                 Name = sk,
                 Value = sk.Length.ToString()
             }).ToList();
@@ -75,7 +76,8 @@ namespace HfsChargesContainer.Tests.Helpers
                 .Setup(c => c.GetParametersAsync(
                     It.IsAny<GetParametersRequest>(),
                     It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new GetParametersResponse() {
+                .ReturnsAsync(new GetParametersResponse()
+                {
                     InvalidParameters = new List<string>(),
                     Parameters = expectedSSMParams
                 });
@@ -99,7 +101,8 @@ namespace HfsChargesContainer.Tests.Helpers
             // Clear the environment
             appKeys.ForEach(ak => Environment.SetEnvironmentVariable(ak, null));
 
-            var expectedSSMParams = ssmKeys.Select(sk => new Parameter() {
+            var expectedSSMParams = ssmKeys.Select(sk => new Parameter()
+            {
                 Name = sk,
                 Value = sk.Length.ToString()
             }).ToList();
@@ -108,7 +111,8 @@ namespace HfsChargesContainer.Tests.Helpers
                 .Setup(c => c.GetParametersAsync(
                     It.IsAny<GetParametersRequest>(),
                     It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new GetParametersResponse() {
+                .ReturnsAsync(new GetParametersResponse()
+                {
                     InvalidParameters = new List<string>(),
                     Parameters = expectedSSMParams
                 });
@@ -116,7 +120,7 @@ namespace HfsChargesContainer.Tests.Helpers
             var expectedAppKeyToSSMValMappings = new Dictionary<string, string>();
             expectedSSMParams.ForEach(p => expectedAppKeyToSSMValMappings.Add(_ssmToAppKeyLookup[p.Name], p.Value));
 
-            foreach(var pair in expectedAppKeyToSSMValMappings)
+            foreach (var pair in expectedAppKeyToSSMValMappings)
             {
                 Console.WriteLine($"Key: {pair.Key}; Val={pair.Value}");
             }
@@ -153,7 +157,8 @@ namespace HfsChargesContainer.Tests.Helpers
                 .Setup(c => c.GetParametersAsync(
                     It.IsAny<GetParametersRequest>(),
                     It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new GetParametersResponse() {
+                .ReturnsAsync(new GetParametersResponse()
+                {
                     InvalidParameters = notFoundSSMKeys,
                     Parameters = new List<Parameter>()
                 });
@@ -162,7 +167,7 @@ namespace HfsChargesContainer.Tests.Helpers
             Action loadRuntimeVars = () => _classUnderTest.LoadRuntimeEnvironmentVariables();
 
             // assert
-           loadRuntimeVars.Should().Throw<ParameterNotFoundException>().WithMessage($"*{expectedErrorMsg}*");
+            loadRuntimeVars.Should().Throw<ParameterNotFoundException>().WithMessage($"*{expectedErrorMsg}*");
         }
 
         [Theory]

--- a/HfsChargesContainer.Tests/Helpers/RuntimeEnvVarsHandlerTests.cs
+++ b/HfsChargesContainer.Tests/Helpers/RuntimeEnvVarsHandlerTests.cs
@@ -177,6 +177,17 @@ namespace HfsChargesContainer.Tests.Helpers
         [InlineData("production")]
         public void RuntimeEnvVarsHandlerCorrectlyPopulatesTheSSMKeyNameEnvironmentsUponBeingInitialized(string environment)
         {
+            // arrange
+            _ssmClientMock
+                .Setup(c => c.GetParametersAsync(
+                    It.IsAny<GetParametersRequest>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new GetParametersResponse()
+                {
+                    InvalidParameters = new List<string>(),
+                    Parameters = new List<Parameter>()
+                });
+
             // act
             var runtimeVarHandler = new RuntimeEnvVarsHandler(environment, ssmClient: _ssmClientMock.Object);
             runtimeVarHandler.LoadRuntimeEnvironmentVariables();

--- a/HfsChargesContainer.Tests/Helpers/RuntimeEnvVarsHandlerTests.cs
+++ b/HfsChargesContainer.Tests/Helpers/RuntimeEnvVarsHandlerTests.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Amazon.SimpleSystemsManagement;
+using Amazon.SimpleSystemsManagement.Model;
+using FluentAssertions;
+using HfsChargesContainer.Helpers;
+using HfsChargesContainer.Helpers.Interfaces;
+using Moq;
+using Xunit;
+
+namespace HfsChargesContainer.Tests.Helpers
+{
+    public class RuntimeEnvVarsHandlerTests
+    {
+        private Dictionary<string, string> _ssmToAppKeyLookup;
+        private Mock<IAmazonSimpleSystemsManagement> _ssmClientMock;
+        private IRuntimeEnvVarsHandler _classUnderTest;
+
+        public RuntimeEnvVarsHandlerTests()
+        {
+            _ssmToAppKeyLookup = new ()
+            {
+                { "/area-of-service/environment/db-host", "DB_HOST" },
+                { "/nightly-job/environment/google-api-key", "GOOGLE_API_KEY" },
+                { "/area-of-service/environment/db-password", "DB_PASSWORD" },
+            };
+            _ssmClientMock = new Mock<IAmazonSimpleSystemsManagement>();
+            _classUnderTest = new RuntimeEnvVarsHandler("environment", _ssmClientMock.Object, _ssmToAppKeyLookup);
+        }
+
+        [Fact]
+        public void RuntimeEnvVarsHandlerRequestsTheSSMKeysMatchingOnesFromSSMLookupDictionary()
+        {
+            // arrange
+            var expectedSSMKeys = _ssmToAppKeyLookup.Keys.ToList();
+
+            _ssmClientMock
+                .Setup(c => c.GetParametersAsync(
+                    It.IsAny<GetParametersRequest>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new GetParametersResponse());
+
+            // act
+            _classUnderTest.LoadRuntimeEnvironmentVariables();
+
+            // assert
+            _ssmClientMock.Verify(
+                u => u.GetParametersAsync(
+                    It.Is<GetParametersRequest>(
+                        request => expectedSSMKeys.All(
+                            key => request.Names.Contains(key)
+                        )),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public void RuntimeEnvVarsHandlerSetsTheEnvironment()
+        {
+            // arrange
+            var appKeys = _ssmToAppKeyLookup.Values.ToList();
+            var ssmKeys = _ssmToAppKeyLookup.Keys.ToList();
+
+            // Clear the environment
+            appKeys.ForEach(ak => Environment.SetEnvironmentVariable(ak, null));
+
+            var expectedSSMParams = ssmKeys.Select(sk => new Parameter() {
+                Name = sk,
+                Value = sk.Length.ToString()
+            }).ToList();
+
+            _ssmClientMock
+                .Setup(c => c.GetParametersAsync(
+                    It.IsAny<GetParametersRequest>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new GetParametersResponse() {
+                    InvalidParameters = new List<string>(),
+                    Parameters = expectedSSMParams
+                });
+
+            // act
+            _classUnderTest.LoadRuntimeEnvironmentVariables();
+
+            // assert
+            var runtimeEnvVarVals = appKeys.Select(ak => Environment.GetEnvironmentVariable(ak));
+
+            runtimeEnvVarVals.Should().NotContainNulls();
+        }
+
+        [Fact]
+        public void RuntimeEnvVarsHandlerMapsSSMValuesToAppScopedEnvVarKeyNamesCorrectly()
+        {
+            // arrange
+            var appKeys = _ssmToAppKeyLookup.Values.ToList();
+            var ssmKeys = _ssmToAppKeyLookup.Keys.ToList();
+
+            // Clear the environment
+            appKeys.ForEach(ak => Environment.SetEnvironmentVariable(ak, null));
+
+            var expectedSSMParams = ssmKeys.Select(sk => new Parameter() {
+                Name = sk,
+                Value = sk.Length.ToString()
+            }).ToList();
+
+            _ssmClientMock
+                .Setup(c => c.GetParametersAsync(
+                    It.IsAny<GetParametersRequest>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new GetParametersResponse() {
+                    InvalidParameters = new List<string>(),
+                    Parameters = expectedSSMParams
+                });
+
+            var expectedAppKeyToSSMValMappings = new Dictionary<string, string>();
+            expectedSSMParams.ForEach(p => expectedAppKeyToSSMValMappings.Add(_ssmToAppKeyLookup[p.Name], p.Value));
+
+            foreach(var pair in expectedAppKeyToSSMValMappings)
+            {
+                Console.WriteLine($"Key: {pair.Key}; Val={pair.Value}");
+            }
+
+            // act
+            _classUnderTest.LoadRuntimeEnvironmentVariables();
+
+            // assert
+            var runtimeEnvVarKeyVal = appKeys.Select(ak => new
+            {
+                AppKeyName = ak,
+                Value = Environment.GetEnvironmentVariable(ak)
+            }).ToList();
+
+            foreach (var runtimeEnvVar in runtimeEnvVarKeyVal)
+            {
+                var expectedEnvVarValue = expectedAppKeyToSSMValMappings[runtimeEnvVar.AppKeyName];
+                runtimeEnvVar.Value.Should().Be(expectedEnvVarValue);
+            }
+        }
+
+        [Fact]
+        public void RuntimeEnvVarsHandlerThrowsWhenMissingSSMKeysAreEncountered()
+        {
+            // arrange
+            var notFoundSSMKeys = new List<string>() {
+                "/hfs-nightly/environment/sns-arn",
+                "/hackney/environment/some-token"
+            };
+
+            var expectedErrorMsg = string.Join(", ", notFoundSSMKeys);
+
+            _ssmClientMock
+                .Setup(c => c.GetParametersAsync(
+                    It.IsAny<GetParametersRequest>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new GetParametersResponse() {
+                    InvalidParameters = notFoundSSMKeys,
+                    Parameters = new List<Parameter>()
+                });
+
+            // act
+            Action loadRuntimeVars = () => _classUnderTest.LoadRuntimeEnvironmentVariables();
+
+            // assert
+           loadRuntimeVars.Should().Throw<ParameterNotFoundException>().WithMessage($"*{expectedErrorMsg}*");
+        }
+    }
+}

--- a/HfsChargesContainer.Tests/Helpers/RuntimeEnvVarsHandlerTests.cs
+++ b/HfsChargesContainer.Tests/Helpers/RuntimeEnvVarsHandlerTests.cs
@@ -164,5 +164,23 @@ namespace HfsChargesContainer.Tests.Helpers
             // assert
            loadRuntimeVars.Should().Throw<ParameterNotFoundException>().WithMessage($"*{expectedErrorMsg}*");
         }
+
+        [Theory]
+        [InlineData("local")]
+        [InlineData("development")]
+        [InlineData("staging")]
+        [InlineData("production")]
+        public void RuntimeEnvVarsHandlerCorrectlyPopulatesTheSSMKeyNameEnvironmentsUponBeingInitialized(string environment)
+        {
+            // act
+            var runtimeVarHandler = new RuntimeEnvVarsHandler(environment, ssmClient: _ssmClientMock.Object);
+            runtimeVarHandler.LoadRuntimeEnvironmentVariables();
+
+            // assert
+            _ssmClientMock.Verify(h => h.GetParametersAsync(
+                It.Is<GetParametersRequest>(r => r.Names.All(n => n.Contains($"/{environment}/"))),
+                It.IsAny<CancellationToken>()
+            ), Times.Once);
+        }
     }
 }

--- a/HfsChargesContainer.Tests/HfsChargesContainer.Tests.csproj
+++ b/HfsChargesContainer.Tests/HfsChargesContainer.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.7.200.22" />
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Moq" Version="4.18.4" />

--- a/HfsChargesContainer.Tests/StartupTests.cs
+++ b/HfsChargesContainer.Tests/StartupTests.cs
@@ -1,0 +1,66 @@
+using System;
+using FluentAssertions;
+using HfsChargesContainer.Helpers.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace HfsChargesContainer.Tests
+{
+    public class StartupTests
+    {
+        private Mock<IRuntimeEnvVarsHandler> _runtimeEnvVarHandlerMock;
+        private IServiceCollection _serviceCollection = new ServiceCollection();
+        private Startup _classUnderTest;
+
+        public StartupTests()
+        {
+
+            _runtimeEnvVarHandlerMock = new Mock<IRuntimeEnvVarsHandler>();
+            _classUnderTest = new Startup(_serviceCollection, _runtimeEnvVarHandlerMock.Object);
+        }
+
+        [Fact]
+        public void StartupShouldFailUponInitializingIfHostEnvironmentIsNotSpecified()
+        {
+            // arrange
+            Environment.SetEnvironmentVariable("ENVIRONMENT", null);
+
+            // act
+            Action initializeStartup = () => new Startup();
+
+            // arrange
+            initializeStartup.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void StartupConfigureEnvironmentDoesNotOverrideEnvVarsInLocalEnvironment()
+        {
+            // arrange
+            Environment.SetEnvironmentVariable("ENVIRONMENT", "local");
+
+            // act
+            _classUnderTest.ConfigureEnvironment();
+
+            // assert
+            _runtimeEnvVarHandlerMock.Verify(h => h.LoadRuntimeEnvironmentVariables(), Times.Never);
+        }
+
+        [Theory]
+        [InlineData("development")]
+        [InlineData("staging")]
+        [InlineData("production")]
+        public void StartupConfigureEnvironmentLoadsRuntimeVarsInNonLocalEnvironment(string environment)
+        {
+            // arrange
+            Environment.SetEnvironmentVariable("ENVIRONMENT", environment);
+
+            // act
+            _classUnderTest.ConfigureEnvironment();
+
+            // assert
+            _runtimeEnvVarHandlerMock.Verify(h => h.LoadRuntimeEnvironmentVariables(), Times.Once);
+        }
+
+    }
+}

--- a/HfsChargesContainer.Tests/StartupTests.cs
+++ b/HfsChargesContainer.Tests/StartupTests.cs
@@ -62,5 +62,68 @@ namespace HfsChargesContainer.Tests
             _runtimeEnvVarHandlerMock.Verify(h => h.LoadRuntimeEnvironmentVariables(), Times.Once);
         }
 
+        [Theory]
+        [InlineData("CHARGES_BATCH_YEARS")]
+        [InlineData("BATCH_SIZE")]
+        public void StartupConfigureOptionsThrowsWhenBatchYearsOrBatchSizeEnvVarsAreMissing(string appVarKey)
+        {
+            // arrange
+            // setting these to avoid early failure:
+            Environment.SetEnvironmentVariable("CHARGES_BATCH_YEARS", "2022;2023");
+            Environment.SetEnvironmentVariable("BATCH_SIZE", "250");
+
+            // configuring failure on specific environment variable
+            Environment.SetEnvironmentVariable(appVarKey, null);
+
+            // act
+            Action configureOptions = () => _classUnderTest.ConfigureOptions(_serviceCollection);
+
+            // assert
+            configureOptions.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void StartupConfigureGoogleClientThrowsWhenGoogleCredentialsAreMissing()
+        {
+            // arrange
+            // setting these to avoid early failure:
+            Environment.SetEnvironmentVariable("CHARGES_BATCH_YEARS", "2022;2023");
+            Environment.SetEnvironmentVariable("BATCH_SIZE", "250");
+
+            // configuring failure on Google Credentials
+            Environment.SetEnvironmentVariable("GOOGLE_API_KEY", null);
+
+            // act
+            Action configureGoogleClient = () => _classUnderTest.ConfigureGoogleClient(_serviceCollection);
+
+            // assert
+            configureGoogleClient.Should().Throw<ArgumentNullException>();
+        }
+
+        [Theory]
+        [InlineData("DB_HOST")]
+        [InlineData("DB_NAME")]
+        [InlineData("DB_USER")]
+        [InlineData("DB_PASSWORD")]
+        public void StartupConfigureDatabaseContextThrowsWhenEitherOfTheDatabaseEnvVarsIsMissing(string appVarKey)
+        {
+            // arrange
+            // setting these to avoid early failure:
+            Environment.SetEnvironmentVariable("CHARGES_BATCH_YEARS", "2022;2023");
+            Environment.SetEnvironmentVariable("BATCH_SIZE", "250");
+            Environment.SetEnvironmentVariable("DB_HOST", "url_to_host");
+            Environment.SetEnvironmentVariable("DB_NAME", "my_db_name");
+            Environment.SetEnvironmentVariable("DB_USER", "my_db_user");
+            Environment.SetEnvironmentVariable("DB_PASSWORD", "secret_password");
+
+            // configuring failure on specific environment variable
+            Environment.SetEnvironmentVariable(appVarKey, null);
+
+            // act
+            Action configureDbContext = () => _classUnderTest.ConfigureDatabaseContext(_serviceCollection);
+
+            // assert
+            configureDbContext.Should().Throw<ArgumentNullException>();
+        }
     }
 }

--- a/HfsChargesContainer/Helpers/Interfaces/IRuntimeEnvVarsHandler.cs
+++ b/HfsChargesContainer/Helpers/Interfaces/IRuntimeEnvVarsHandler.cs
@@ -1,0 +1,7 @@
+namespace HfsChargesContainer.Helpers.Interfaces
+{
+    public interface IRuntimeEnvVarsHandler
+    {
+        public void LoadRuntimeEnvironmentVariables();
+    }
+}

--- a/HfsChargesContainer/Helpers/RuntimeEnvVarsHandler.cs
+++ b/HfsChargesContainer/Helpers/RuntimeEnvVarsHandler.cs
@@ -24,7 +24,8 @@ namespace HfsChargesContainer.Helpers
         private GetParametersResponse GetSSMParameters(List<string> ssmKeys)
         {
             var getParamsTask = _ssmClient.GetParametersAsync(
-                new GetParametersRequest {
+                new GetParametersRequest
+                {
                     Names = ssmKeys,
                     WithDecryption = true
                 });
@@ -54,7 +55,8 @@ namespace HfsChargesContainer.Helpers
                     $"The following parameters were not found: {string.Join(", ", ssmParameters.InvalidParameters)}."
                 );
 
-            ssmParameters.Parameters.ForEach(p => {
+            ssmParameters.Parameters.ForEach(p =>
+            {
                 var variableSSMName = p.Name;
                 var variableValue = p.Value;
 

--- a/HfsChargesContainer/Helpers/RuntimeEnvVarsHandler.cs
+++ b/HfsChargesContainer/Helpers/RuntimeEnvVarsHandler.cs
@@ -1,0 +1,66 @@
+using Amazon;
+using Amazon.SimpleSystemsManagement;
+using Amazon.SimpleSystemsManagement.Model;
+using HfsChargesContainer.Helpers.Interfaces;
+using HfsChargesContainer.Options;
+
+namespace HfsChargesContainer.Helpers
+{
+    public class RuntimeEnvVarsHandler : IRuntimeEnvVarsHandler
+    {
+        private readonly IAmazonSimpleSystemsManagement _ssmClient;
+        private readonly Dictionary<string, string> _ssmToAppNameLookup;
+
+        public RuntimeEnvVarsHandler(
+            string environment,
+            IAmazonSimpleSystemsManagement? ssmClient = null,
+            Dictionary<string, string>? ssmToAppNameLookup = null
+        )
+        {
+            _ssmClient = ssmClient ?? new AmazonSimpleSystemsManagementClient(RegionEndpoint.EUWest2);
+            _ssmToAppNameLookup = ssmToAppNameLookup ?? new EnvVarConfig(environment).EnvVarSSMToAppNameLookup;
+        }
+
+        private GetParametersResponse GetSSMParameters(List<string> ssmKeys)
+        {
+            var getParamsTask = _ssmClient.GetParametersAsync(
+                new GetParametersRequest {
+                    Names = ssmKeys,
+                    WithDecryption = true
+                });
+
+            return getParamsTask.Result;
+        }
+
+        private string MapVariableSSMKeyToAppName(string ssmName)
+        {
+            try
+            {
+                return _ssmToAppNameLookup[ssmName];
+            }
+            catch
+            {
+                throw new ArgumentException($"SSM key: {ssmName} has no application-scope name mapping.");
+            }
+        }
+
+        public void LoadRuntimeEnvironmentVariables()
+        {
+            var ssmKeys = _ssmToAppNameLookup.Keys.ToList();
+            var ssmParameters = GetSSMParameters(ssmKeys);
+
+            if (ssmParameters.InvalidParameters.Any())
+                throw new ParameterNotFoundException(
+                    $"The following parameters were not found: {string.Join(", ", ssmParameters.InvalidParameters)}."
+                );
+
+            ssmParameters.Parameters.ForEach(p => {
+                var variableSSMName = p.Name;
+                var variableValue = p.Value;
+
+                var variableAppName = MapVariableSSMKeyToAppName(variableSSMName);
+                Environment.SetEnvironmentVariable(variableAppName, variableValue);
+            });
+        }
+    }
+}

--- a/HfsChargesContainer/HfsChargesContainer.csproj
+++ b/HfsChargesContainer/HfsChargesContainer.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.200.19" />
+    <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.7.200.22" />
     <PackageReference Include="EFCore.BulkExtensions" Version="7.1.5" />
     <PackageReference Include="Google.Apis.Sheets.v4" Version="1.61.0.3113" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.9" />

--- a/HfsChargesContainer/Options/EnvVarConfig.cs
+++ b/HfsChargesContainer/Options/EnvVarConfig.cs
@@ -15,7 +15,7 @@ namespace HfsChargesContainer.Options
 
         public EnvVarConfig(string environment)
         {
-            EnvVarSSMToAppNameLookup = new ()
+            EnvVarSSMToAppNameLookup = new()
             {
                 { $"/housing-finance/{environment}/charges-batch-years", "CHARGES_BATCH_YEARS" },
                 { $"/housing-finance/{environment}/google-application-credentials-json", "GOOGLE_API_KEY" },

--- a/HfsChargesContainer/Options/EnvVarConfig.cs
+++ b/HfsChargesContainer/Options/EnvVarConfig.cs
@@ -18,6 +18,7 @@ namespace HfsChargesContainer.Options
             EnvVarSSMToAppNameLookup = new()
             {
                 { $"/housing-finance/{environment}/charges-batch-years", "CHARGES_BATCH_YEARS" },
+                { $"/housing-finance/{environment}/bulk-insert-batch-size", "BATCH_SIZE" },
                 { $"/housing-finance/{environment}/google-application-credentials-json", "GOOGLE_API_KEY" },
                 { $"/housing-finance/{environment}/db-host", "DB_HOST" },
                 { $"/housing-finance/{environment}/mssql-database", "DB_NAME" },

--- a/HfsChargesContainer/Options/EnvVarConfig.cs
+++ b/HfsChargesContainer/Options/EnvVarConfig.cs
@@ -1,0 +1,29 @@
+namespace HfsChargesContainer.Options
+{
+    /// <summary>
+    /// These options define which environment variables get pulled down from SSM during runtime.
+    /// 
+    /// If you want to add/remove an SSM key from being pulled down, then add/remove it from this
+    /// dictionary.
+    /// 
+    /// Similarly, if you want to make some application variable to look at a different SSM key, then
+    /// simply change the name of SSM key name next to app variable key name.
+    /// </summary>
+    public class EnvVarConfig
+    {
+        public Dictionary<string, string> EnvVarSSMToAppNameLookup { get; }
+
+        public EnvVarConfig(string environment)
+        {
+            EnvVarSSMToAppNameLookup = new ()
+            {
+                { $"/housing-finance/{environment}/charges-batch-years", "CHARGES_BATCH_YEARS" },
+                { $"/housing-finance/{environment}/google-application-credentials-json", "GOOGLE_API_KEY" },
+                { $"/housing-finance/{environment}/db-host", "DB_HOST" },
+                { $"/housing-finance/{environment}/mssql-database", "DB_NAME" },
+                { $"/housing-finance/{environment}/mssql-username", "DB_USER" },
+                { $"/housing-finance/{environment}/db-password", "DB_PASSWORD" },
+            };
+        }
+    }
+}


### PR DESCRIPTION
# What:
 - Made the application retrieve auth secrets from the SSM directly on runtime.
 - Made the application retrieve charges batch years from the SSM directly on runtime.

# Why:
 - This lowers the likelihood of secrets getting exposed in a console during the infrastructure deploy time.
 - This decouples the charges batch years variable update _(which needs to be done every start of new financial year)_ from having to be done by re-deploying the infrastructure. This achieves a much smoother charges batch years update.

# Notes:
 - Added Startup tests for previously added Startup functionality.
 - The SSM parameter retrieval depends on RuntimeEnvVarHandler instance, which in turn depends on SSM client instance. These could not be configured via dependency injection because they need to do their job during startup _(meaning before services get built)_ so that any missing env vars throw timely exceptions. As such, we have constructors newing up instance themselves.
 - I've made a separate class 'EnvVarConfig' to configure what SSM keys correspond to what application env var keys. This same class is also being used as a reference to retrieve the listed SSM parameters. Unlike some of the previous SSM solutions, this class gives a bit more flexibility in parameter retrieval: the keys no longer need to strictly be under the same ssm path; the keys don't need to incude environment name in them _(which is redundant within our SSM stores to begin with due to every environment having its own account)_.