### PR TITLE
change the deployment executor to one that contains aws cli

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,12 +115,12 @@ jobs:
       - deploy-image:
           environment: "development"
   deploy-to-staging:
-    executor: docker-dotnet
+    executor: cci-aws
     steps:
       - deploy-image:
           environment: "staging"
   deploy-to-production:
-    executor: docker-dotnet
+    executor: cci-aws
     steps:
       - deploy-image:
           environment: "production"


### PR DESCRIPTION
# What:
 - Changed the staging/prod deployment CCI executor to one that contains aws-cli.

# Why:
 - Because the deployment process depends on aws-cli for both deployment of the image & the pull-down of the needed environment variables.
