### PR TITLE
Update the DB name and DB username SSM keys to match ones on Interim API.

### DIFF
--- a/HfsChargesContainer/Options/EnvVarConfig.cs
+++ b/HfsChargesContainer/Options/EnvVarConfig.cs
@@ -21,8 +21,8 @@ namespace HfsChargesContainer.Options
                 { $"/housing-finance/{environment}/bulk-insert-batch-size", "BATCH_SIZE" },
                 { $"/housing-finance/{environment}/google-application-credentials-json", "GOOGLE_API_KEY" },
                 { $"/housing-finance/{environment}/db-host", "DB_HOST" },
-                { $"/housing-finance/{environment}/mssql-database", "DB_NAME" },
-                { $"/housing-finance/{environment}/mssql-username", "DB_USER" },
+                { $"/housing-finance/{environment}/db-database", "DB_NAME" },
+                { $"/housing-finance/{environment}/db-username", "DB_USER" },
                 { $"/housing-finance/{environment}/db-password", "DB_PASSWORD" },
             };
         }


### PR DESCRIPTION
# What:
 - Update the SSM key names by which the values get retrieved.

# Why:
 - The current ones that don't match the Interim API only exist on development & are making the `staging` environment fall over.
 - It's better to update the code to point to the correct keys than to create a duplicate pair of non-matching keys on `staging` and `production` environments _(which would need to be maintained to be consistent with ones used by the interim api)_.