### PR TITLE
More CW logs on Application Exceptions.

### DIFF
--- a/HfsChargesContainer/Program.cs
+++ b/HfsChargesContainer/Program.cs
@@ -34,7 +34,7 @@ catch (Exception ex)
 
     LoggingHandler.LogError(
         $"Exception Type: {ex.GetType().Name}\nMessage: {ex.Message}\nStack Trace: {ex.StackTrace}\n\n");
-    
+
     // Throw to terminate with non-zero exit
     throw;
 }

--- a/HfsChargesContainer/Program.cs
+++ b/HfsChargesContainer/Program.cs
@@ -1,4 +1,4 @@
-using HfsChargesContainer;
+﻿using HfsChargesContainer;
 using HfsChargesContainer.Helpers;
 
 try
@@ -32,6 +32,9 @@ catch (Exception ex)
 
     LoggingHandler.LogError("\nApplication exception:\n");
 
-    // Throw to get exception logged.
+    LoggingHandler.LogError(
+        $"Exception Type: {ex.GetType().Name}\nMessage: {ex.Message}\nStack Trace: {ex.StackTrace}\n\n");
+    
+    // Throw to terminate with non-zero exit
     throw;
 }

--- a/HfsChargesContainer/Program.cs
+++ b/HfsChargesContainer/Program.cs
@@ -1,18 +1,18 @@
-﻿using HfsChargesContainer;
+using HfsChargesContainer;
 using HfsChargesContainer.Helpers;
 
 try
 {
-    LoggingHandler.LogError("Application started!\nConfiguring the Start up!");
+    LoggingHandler.LogInfo("Application started!\nConfiguring the Start up!");
 
     var entryPoint = new Startup()
         .ConfigureServices()
         .Build<ProcessEntryPoint>();
 
-    LoggingHandler.LogError("Ready to Run!");
+    LoggingHandler.LogInfo("Ready to Run!");
     await entryPoint.Run();
 
-    LoggingHandler.LogError("Application finished!");
+    LoggingHandler.LogInfo("Application finished!");
 }
 catch (Exception ex)
 {
@@ -26,7 +26,7 @@ catch (Exception ex)
     if (environment == "local")
         throw;
 
-    LoggingHandler.LogError("Attempting to send out an SNS Nofication alert.");
+    LoggingHandler.LogInfo("Attempting to send out an SNS Nofication alert.");
 
     await EmailAlertsHandler.TrySendEmailAlert(ex, environment);
 


### PR DESCRIPTION
# What:
 - Manually log the Application-level exception. 
 - Change the Info level logs to appropriate LogLevel.

# Why:
 - The functionality of the exception getting logged to stderr & subsequently to the console works just fine. However, once deployed to AWS Fargate, the re-throw of the application exception is not being read from stderr and is not transferred into CW.

# Notes:
 - To learn more details about the exception, the typical exception reporting is done manually through the logger.