### PR TITLE
Added Retry Policy for the LoadChargesUseCase's "Fetch Charges by Sheet Tab" action.

### DIFF
--- a/HfsChargesContainer.Tests/HfsChargesContainer.Tests.csproj
+++ b/HfsChargesContainer.Tests/HfsChargesContainer.Tests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="Polly" Version="8.3.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/HfsChargesContainer.Tests/HfsChargesContainer.Tests.csproj
+++ b/HfsChargesContainer.Tests/HfsChargesContainer.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AutoFixture" Version="4.18.1" />
     <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.7.200.22" />
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />

--- a/HfsChargesContainer.Tests/RandomGen.cs
+++ b/HfsChargesContainer.Tests/RandomGen.cs
@@ -1,10 +1,6 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using AutoFixture;
-using AutoFixture.Dsl;
-using HfsChargesContainer.Domain;
+
 
 namespace HfsChargesContainer.Tests
 {
@@ -12,13 +8,7 @@ namespace HfsChargesContainer.Tests
     {
         private static Fixture _fixture = new Fixture();
 
-        // public BatchLogDomain 
-
         public static TItem Create<TItem>() => _fixture.Create<TItem>();
-        // public static TItem CreateCustom<TItem>(this IPostprocessComposer<TItem> itemComposer) => itemComposer.Create();
-        // public static ICustomizationComposer<TItem> Build<TItem>() => _fixture.Build<TItem>();
         public static IEnumerable<TItem> CreateMany<TItem>(int quantity = 3) => _fixture.CreateMany<TItem>(quantity);
-
-        
     }
 }

--- a/HfsChargesContainer.Tests/RandomGen.cs
+++ b/HfsChargesContainer.Tests/RandomGen.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AutoFixture;
+using AutoFixture.Dsl;
+using HfsChargesContainer.Domain;
+
+namespace HfsChargesContainer.Tests
+{
+    public static class RandomGen
+    {
+        private static Fixture _fixture = new Fixture();
+
+        // public BatchLogDomain 
+
+        public static TItem Create<TItem>() => _fixture.Create<TItem>();
+        // public static TItem CreateCustom<TItem>(this IPostprocessComposer<TItem> itemComposer) => itemComposer.Create();
+        // public static ICustomizationComposer<TItem> Build<TItem>() => _fixture.Build<TItem>();
+        public static IEnumerable<TItem> CreateMany<TItem>(int quantity = 3) => _fixture.CreateMany<TItem>(quantity);
+
+        
+    }
+}

--- a/HfsChargesContainer.Tests/Resilience/ChargesFetchSheetRetryPolicyTests.cs
+++ b/HfsChargesContainer.Tests/Resilience/ChargesFetchSheetRetryPolicyTests.cs
@@ -99,7 +99,7 @@ namespace HfsChargesContainer.Tests.Resilience
             .Callback(action)
             .ReturnsAsync(RandomGen.CreateMany<ChargesAuxDomain>().ToList());
 
-            // It's going to be 1 failure + sheet tab count of successes (retry + remaining keys)
+            // It's going to be failure count on 1st sheet tab + sheet tab count of successes
             var expectedCallCount = Enum.GetValues(typeof(RentGroup)).Length + failureCount;
 
             // act

--- a/HfsChargesContainer.Tests/Resilience/ChargesFetchSheetRetryPolicyTests.cs
+++ b/HfsChargesContainer.Tests/Resilience/ChargesFetchSheetRetryPolicyTests.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using HfsChargesContainer.Domain;
+using HfsChargesContainer.Gateways.Interfaces;
+using HfsChargesContainer.UseCases;
+using HfsChargesContainer.UseCases.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Polly;
+using Xunit;
+
+namespace HfsChargesContainer.Tests.Resilience
+{
+    public class ChargesFetchSheetRetryPolicyTests
+    {
+        Mock<IBatchLogGateway> _mockBatchLogGateway;
+        Mock<IBatchLogErrorGateway> _mockBatchLogErrorGateway;
+        Mock<IChargesBatchYearsGateway> _mockChargesBatchYearsGateway;
+        Mock<IChargesGateway> _mockChargesGateway;
+        Mock<IGoogleFileSettingGateway> _mockGoogleFileSettingGateway;
+        Mock<IGoogleClientService> _mockGoogleClientService;
+        ILoadChargesUseCase _ucWithTestedRetryPolicy;
+
+
+        public ChargesFetchSheetRetryPolicyTests()
+        {            
+            _mockBatchLogGateway = new Mock<IBatchLogGateway>();
+            _mockBatchLogErrorGateway = new Mock<IBatchLogErrorGateway>();
+            _mockChargesBatchYearsGateway = new Mock<IChargesBatchYearsGateway>();
+            _mockChargesGateway = new Mock<IChargesGateway>();
+            _mockGoogleFileSettingGateway = new Mock<IGoogleFileSettingGateway>();
+            _mockGoogleClientService = new Mock<IGoogleClientService>();
+
+            Environment.SetEnvironmentVariable("ENVIRONMENT", "tests");
+
+            var services = new ServiceCollection();
+            var serviceProvider = new Startup(services);
+
+            serviceProvider.ConfigureResiliencePolicies(services);
+            var builtProvider = services.BuildServiceProvider();
+
+            var fetchSheetRetryPolicy = builtProvider.GetService<IAsyncPolicy<IList<ChargesAuxDomain>>>();
+
+            _ucWithTestedRetryPolicy = new LoadChargesUseCase(
+                _mockBatchLogGateway.Object,
+                _mockBatchLogErrorGateway.Object,
+                _mockChargesBatchYearsGateway.Object,
+                _mockChargesGateway.Object,
+                _mockGoogleFileSettingGateway.Object,
+                _mockGoogleClientService.Object,
+                fetchSheetRetryPolicy
+            );
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        public async Task FetchChargesSheetRetryPolicyRetriesTheFetchUponGoogleClientServiceReadSheetsFailure(int failureCount)
+        {
+            // arrange
+            _mockBatchLogGateway
+                .Setup(bl => bl.CreateAsync(It.IsAny<string>(), It.IsAny<bool>()))
+                .ReturnsAsync(RandomGen.Create<BatchLogDomain>());
+
+            // returns a year that matches 1 year from GFSs
+            var chargesBatchYear = RandomGen.Create<ChargesBatchYearDomain>();
+            _mockChargesBatchYearsGateway
+                .Setup(cby => cby.GetPendingYear())
+                .ReturnsAsync(chargesBatchYear);
+
+            // returns non-empty list of GFSs
+            var googleFileSettings = RandomGen.CreateMany<GoogleFileSettingDomain>(quantity: 1).ToList();
+            googleFileSettings[0].FileYear = chargesBatchYear.Year;
+            _mockGoogleFileSettingGateway
+                .Setup(gfs => gfs.GetSettingsByLabel(It.IsAny<string>()))
+                .ReturnsAsync(googleFileSettings);
+
+            // We don't want to sit for 40 minutes waiting for all 10 retries.
+            var retryCount = failureCount; 
+
+            Action<string, string, string> action = (string _, string _, string _) =>
+            {
+                if (retryCount > 0)
+                {
+                    retryCount = retryCount - 1;
+                    throw new Exception("Sheets Fetch Failed!");
+                }
+            };
+
+            _mockGoogleClientService.Setup(
+                gc => gc.ReadSheetToEntitiesAsync<ChargesAuxDomain>(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                )
+            )
+            .Callback(action)
+            .ReturnsAsync(RandomGen.CreateMany<ChargesAuxDomain>().ToList());
+
+            // It's going to be 1 failure + sheet tab count of successes (retry + remaining keys)
+            var expectedCallCount = Enum.GetValues(typeof(RentGroup)).Length + failureCount;
+
+            // act
+            await _ucWithTestedRetryPolicy.ExecuteAsync();
+
+            // assert
+            _mockGoogleClientService.Verify(
+                gc => gc.ReadSheetToEntitiesAsync<ChargesAuxDomain>(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ), Times.Exactly(expectedCallCount)
+            );
+        }
+    }
+}

--- a/HfsChargesContainer.Tests/Resilience/ChargesFetchSheetRetryPolicyTests.cs
+++ b/HfsChargesContainer.Tests/Resilience/ChargesFetchSheetRetryPolicyTests.cs
@@ -25,7 +25,7 @@ namespace HfsChargesContainer.Tests.Resilience
 
 
         public ChargesFetchSheetRetryPolicyTests()
-        {            
+        {
             _mockBatchLogGateway = new Mock<IBatchLogGateway>();
             _mockBatchLogErrorGateway = new Mock<IBatchLogErrorGateway>();
             _mockChargesBatchYearsGateway = new Mock<IChargesBatchYearsGateway>();
@@ -78,7 +78,7 @@ namespace HfsChargesContainer.Tests.Resilience
                 .ReturnsAsync(googleFileSettings);
 
             // We don't want to sit for 40 minutes waiting for all 10 retries.
-            var retryCount = failureCount; 
+            var retryCount = failureCount;
 
             Action<string, string, string> action = (string _, string _, string _) =>
             {

--- a/HfsChargesContainer.Tests/UseCases/LoadChargesUseCaseTests.cs
+++ b/HfsChargesContainer.Tests/UseCases/LoadChargesUseCaseTests.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using HfsChargesContainer.Domain;
+using HfsChargesContainer.Gateways.Interfaces;
+using HfsChargesContainer.UseCases;
+using HfsChargesContainer.UseCases.Interfaces;
+using Moq;
+using Polly;
+using Xunit;
+
+namespace HfsChargesContainer.Tests.UseCases
+{
+    using FetchChargesSheet = Func<Task<IList<ChargesAuxDomain>>>;
+
+    public class LoadChargesUseCaseTests
+    {
+        Mock<IBatchLogGateway> _mockBatchLogGateway;
+        Mock<IBatchLogErrorGateway> _mockBatchLogErrorGateway;
+        Mock<IChargesBatchYearsGateway> _mockChargesBatchYearsGateway;
+        Mock<IChargesGateway> _mockChargesGateway;
+        Mock<IGoogleFileSettingGateway> _mockGoogleFileSettingGateway;
+        Mock<IGoogleClientService> _mockGoogleClientService;
+        Mock<IAsyncPolicy<IList<ChargesAuxDomain>>> _mockFetchSheetRetryPolicy;
+        ILoadChargesUseCase _classUnderTest;
+
+        public LoadChargesUseCaseTests()
+        {
+            _mockBatchLogGateway = new Mock<IBatchLogGateway>();
+            _mockBatchLogErrorGateway = new Mock<IBatchLogErrorGateway>();
+            _mockChargesBatchYearsGateway = new Mock<IChargesBatchYearsGateway>();
+            _mockChargesGateway = new Mock<IChargesGateway>();
+            _mockGoogleFileSettingGateway = new Mock<IGoogleFileSettingGateway>();
+            _mockGoogleClientService = new Mock<IGoogleClientService>();
+            _mockFetchSheetRetryPolicy = new Mock<IAsyncPolicy<IList<ChargesAuxDomain>>>();
+
+            _classUnderTest = new LoadChargesUseCase(
+                _mockBatchLogGateway.Object,
+                _mockBatchLogErrorGateway.Object,
+                _mockChargesBatchYearsGateway.Object,
+                _mockChargesGateway.Object,
+                _mockGoogleFileSettingGateway.Object,
+                _mockGoogleClientService.Object,
+                _mockFetchSheetRetryPolicy.Object
+            );
+        }
+
+        [Fact]
+        public async Task LoadChargesUseCaseCallsTheRetrySheetsPolicyWrapperForEachRentGroupTabWithinTheSheet()
+        {
+            // arrange
+            _mockBatchLogGateway
+                .Setup(bl => bl.CreateAsync(It.IsAny<string>(), It.IsAny<bool>()))
+                .ReturnsAsync(RandomGen.Create<BatchLogDomain>());
+
+            // returns a year that matches 1 year from GFSs
+            var chargesBatchYear = RandomGen.Create<ChargesBatchYearDomain>();
+            _mockChargesBatchYearsGateway
+                .Setup(cby => cby.GetPendingYear())
+                .ReturnsAsync(chargesBatchYear);
+
+            // returns non-empty list of GFSs
+            var googleFileSettings = RandomGen.CreateMany<GoogleFileSettingDomain>(quantity: 1).ToList();
+            googleFileSettings[0].FileYear = chargesBatchYear.Year;
+            _mockGoogleFileSettingGateway
+                .Setup(gfs => gfs.GetSettingsByLabel(It.IsAny<string>()))
+                .ReturnsAsync(googleFileSettings);
+
+            // _mockFetchSheetRetryPolicy returns charges
+            _mockFetchSheetRetryPolicy
+                .Setup(p => p.ExecuteAsync(It.IsAny<FetchChargesSheet>()))
+                .ReturnsAsync(RandomGen.CreateMany<ChargesAuxDomain>().ToList());
+
+            var expectedCallCount = Enum.GetValues(typeof(RentGroup)).Length;
+
+            // act
+            await _classUnderTest.ExecuteAsync();
+
+            // assert
+            _mockFetchSheetRetryPolicy.Verify(
+                p => p.ExecuteAsync(
+                    It.IsAny<FetchChargesSheet>()
+                ),
+                Times.Exactly(expectedCallCount)
+            );
+        }
+
+        [Fact]
+        public async Task LoadChargesUseCaseCallsToTheRetrySheetsPolicyWrapperResultInCallsToTheGoogleClientService()
+        {
+            // arrange
+            _mockBatchLogGateway
+                .Setup(bl => bl.CreateAsync(It.IsAny<string>(), It.IsAny<bool>()))
+                .ReturnsAsync(RandomGen.Create<BatchLogDomain>());
+
+            // returns a year that matches 1 year from GFSs
+            var chargesBatchYear = RandomGen.Create<ChargesBatchYearDomain>();
+            _mockChargesBatchYearsGateway
+                .Setup(cby => cby.GetPendingYear())
+                .ReturnsAsync(chargesBatchYear);
+
+            // returns non-empty list of GFSs
+            var googleFileSettings = RandomGen.CreateMany<GoogleFileSettingDomain>(quantity: 1).ToList();
+            googleFileSettings[0].FileYear = chargesBatchYear.Year;
+            _mockGoogleFileSettingGateway
+                .Setup(gfs => gfs.GetSettingsByLabel(It.IsAny<string>()))
+                .ReturnsAsync(googleFileSettings);
+
+            _mockGoogleClientService.Setup(
+                gc => gc.ReadSheetToEntitiesAsync<ChargesAuxDomain>(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                )
+            ).ReturnsAsync(RandomGen.CreateMany<ChargesAuxDomain>().ToList());
+
+            // obviously, this assumes that the callback is being called. But we're invoking
+            // it with this assumption regardless to see whether the callback itself behaves
+            // correctly. See the google client service mock assertion.
+            _mockFetchSheetRetryPolicy
+                .Setup(
+                    p => p.ExecuteAsync(It.IsAny<FetchChargesSheet>())
+                )
+                .Returns(
+                    (FetchChargesSheet incFunc) => Task.FromResult(incFunc().Result)
+                );
+
+            var expectedCallCount = Enum.GetValues(typeof(RentGroup)).Length;
+
+            // act
+            await _classUnderTest.ExecuteAsync();
+
+            // assert
+            _mockFetchSheetRetryPolicy.Verify(
+                p => p.ExecuteAsync(
+                    It.IsAny<FetchChargesSheet>()
+                ),
+                Times.Exactly(expectedCallCount)
+            );
+
+            _mockGoogleClientService.Verify(
+                gc => gc.ReadSheetToEntitiesAsync<ChargesAuxDomain>(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ), Times.Exactly(expectedCallCount)
+            );
+        }
+    }
+}

--- a/HfsChargesContainer/HfsChargesContainer.csproj
+++ b/HfsChargesContainer/HfsChargesContainer.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Google.Apis.Sheets.v4" Version="1.61.0.3113" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.9" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+    <PackageReference Include="Polly" Version="8.3.1" />
   </ItemGroup>
 
 </Project>

--- a/HfsChargesContainer/HfsChargesContainer.csproj
+++ b/HfsChargesContainer/HfsChargesContainer.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.9" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Polly" Version="8.3.1" />
+    <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
   </ItemGroup>
 
 </Project>

--- a/HfsChargesContainer/Startup.cs
+++ b/HfsChargesContainer/Startup.cs
@@ -82,7 +82,7 @@ namespace HfsChargesContainer
         #region Resilience Pipelines
         public void ConfigureEntityReturnRetry<TOut>(IServiceCollection services) where TOut : class
         {
-            var asyncRetryPolicy =  Policy<TOut>
+            var asyncRetryPolicy = Policy<TOut>
                 .Handle<Exception>()
                 .WaitAndRetryAsync(
                     Backoff.DecorrelatedJitterBackoffV2(

--- a/HfsChargesContainer/Startup.cs
+++ b/HfsChargesContainer/Startup.cs
@@ -43,6 +43,7 @@ namespace HfsChargesContainer
             ConfigureUseCases(services);
             ConfigureEntry(services);
             ConfigureGoogleClient(services);
+            ConfigureResiliencePolicies(services);
 
             return this;
         }

--- a/HfsChargesContainer/Startup.cs
+++ b/HfsChargesContainer/Startup.cs
@@ -80,14 +80,14 @@ namespace HfsChargesContainer
         #region Resilience Pipelines
         public void ConfigureResiliencePolicies(IServiceCollection services)
         {
-            var asyncRetryPolicy =  Policy<List<ChargesAux>>
+            var asyncRetryPolicy =  Policy<IList<ChargesAux>>
                 .Handle<Exception>()
                 .WaitAndRetryAsync(Backoff.DecorrelatedJitterBackoffV2(TimeSpan.FromSeconds(5), retryCount: 10));
 
-            Func<IServiceProvider, AsyncRetryPolicy<List<ChargesAux>>> implementationFactory =
+            Func<IServiceProvider, AsyncRetryPolicy<IList<ChargesAux>>> implementationFactory =
                 (IServiceProvider services) => asyncRetryPolicy;
 
-            services.AddScoped<IAsyncPolicy<List<ChargesAux>>>(implementationFactory);
+            services.AddScoped<IAsyncPolicy<IList<ChargesAux>>>(implementationFactory);
         }
         #endregion
 

--- a/HfsChargesContainer/Startup.cs
+++ b/HfsChargesContainer/Startup.cs
@@ -1,6 +1,7 @@
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Sheets.v4;
+using HfsChargesContainer.Domain;
 using HfsChargesContainer.Gateways;
 using HfsChargesContainer.Gateways.Interfaces;
 using HfsChargesContainer.Helpers;
@@ -80,14 +81,14 @@ namespace HfsChargesContainer
         #region Resilience Pipelines
         public void ConfigureResiliencePolicies(IServiceCollection services)
         {
-            var asyncRetryPolicy =  Policy<IList<ChargesAux>>
+            var asyncRetryPolicy =  Policy<IList<ChargesAuxDomain>>
                 .Handle<Exception>()
                 .WaitAndRetryAsync(Backoff.DecorrelatedJitterBackoffV2(TimeSpan.FromSeconds(5), retryCount: 10));
 
-            Func<IServiceProvider, AsyncRetryPolicy<IList<ChargesAux>>> implementationFactory =
+            Func<IServiceProvider, AsyncRetryPolicy<IList<ChargesAuxDomain>>> implementationFactory =
                 (IServiceProvider services) => asyncRetryPolicy;
 
-            services.AddScoped<IAsyncPolicy<IList<ChargesAux>>>(implementationFactory);
+            services.AddScoped<IAsyncPolicy<IList<ChargesAuxDomain>>>(implementationFactory);
         }
         #endregion
 


### PR DESCRIPTION
# What:
 - Added a Retry Policy with Jitter and Exponential Backoff (for better results).

# Why:
Google Sheets API is unstable. We've gotten like 4-6 internal server errors from it over the past couple of months. These failures are making our Charges nightly ingest process to fail, which affects other nightly procedures down the line such as Refresh Account Balances and Refresh Operating Balances.

# Notes:
 - We don't know much about the type of exception throw due to a blind spot in our logging. The blindspot has been closed as part of #11, however we haven't had an incident since then. Because of this the exception trigger for the retry policy is plainly the any `System.Exception`.
 - From my manual testing, I found that this Retry configuration finishes its 10th (last) retry after around 40 minutes _(exponential backoff - we've got no idea how long the sheet service is out)_.

| Time of day printed for every Retry of 10 retries done given the configuration in this PR |
| ----- |
| ![image](https://github.com/LBHackney-IT/HfsChargesContainer/assets/43747286/f4d5ea8f-cc46-4c60-a16a-5ba95bdff357) |