### PR TITLE
Test the Load Charges usecase's charges sheet cell range selection  logic.

### DIFF
--- a/HfsChargesContainer.Tests/UseCases/LoadChargesUseCaseTests.cs
+++ b/HfsChargesContainer.Tests/UseCases/LoadChargesUseCaseTests.cs
@@ -207,7 +207,7 @@ namespace HfsChargesContainer.Tests.UseCases
 
                 Assert.Equal(sheetId, googleFileSettings.First().GoogleIdentifier);
                 Assert.True(sheetRentGroups.Contains(sheetName));
-                Assert.Equal(cellRange, expectedRange(sheetName));
+                Assert.Equal(cellRange, expectedRange);
             }
         }
 

--- a/HfsChargesContainer.Tests/UseCases/LoadChargesUseCaseTests.cs
+++ b/HfsChargesContainer.Tests/UseCases/LoadChargesUseCaseTests.cs
@@ -205,9 +205,9 @@ namespace HfsChargesContainer.Tests.UseCases
                     ? "A:AZ"
                     : "A:AX";
 
-                Assert.AreEqual(sheetId, googleFileSettings.GoogleIdentifier);
-                Assert.IsTrue(sheetRentGroups.Contains(sheetName));
-                Assert.AreEqual(cellRange, expectedRange(sheetName));
+                Assert.Equal(sheetId, googleFileSettings.First().GoogleIdentifier);
+                Assert.True(sheetRentGroups.Contains(sheetName));
+                Assert.Equal(cellRange, expectedRange(sheetName));
             }
         }
 

--- a/HfsChargesContainer.Tests/UseCases/LoadChargesUseCaseTests.cs
+++ b/HfsChargesContainer.Tests/UseCases/LoadChargesUseCaseTests.cs
@@ -189,7 +189,8 @@ namespace HfsChargesContainer.Tests.UseCases
                     It.IsAny<string>()
                 )
             )
-            .Callback<string, string, string>((sheetId, sheetName, cellRange) => {
+            .Callback<string, string, string>((sheetId, sheetName, cellRange) =>
+            {
                 capturedInputs.Add((sheetId, sheetName, cellRange));
             })
             .ReturnsAsync(RandomGen.CreateMany<ChargesAuxDomain>().ToList());

--- a/HfsChargesContainer.Tests/UseCases/LoadChargesUseCaseTests.cs
+++ b/HfsChargesContainer.Tests/UseCases/LoadChargesUseCaseTests.cs
@@ -13,6 +13,7 @@ using Xunit;
 namespace HfsChargesContainer.Tests.UseCases
 {
     using FetchChargesSheet = Func<Task<IList<ChargesAuxDomain>>>;
+    using ReadGSheetInputsTuple = (string sheetId, string sheetName, string cellRange);
 
     public class LoadChargesUseCaseTests
     {
@@ -146,6 +147,73 @@ namespace HfsChargesContainer.Tests.UseCases
                     It.IsAny<string>()
                 ), Times.Exactly(expectedCallCount)
             );
+        }
+
+        [Fact]
+        public async Task LoadChargesUseCaseGivesToTheRetrySheetsPolicyWrapperAGetChargesSheetCallbackWithTheExpectedParameters()
+        {
+            // arrange
+            var sheetRentGroups = (Enum.GetValues(typeof(RentGroup)) as RentGroup[])
+                .Select(srg => srg.ToString())
+                .ToList();
+
+            _mockBatchLogGateway
+                .Setup(bl => bl.CreateAsync(It.IsAny<string>(), It.IsAny<bool>()))
+                .ReturnsAsync(RandomGen.Create<BatchLogDomain>());
+
+            var chargesBatchYear = RandomGen.Create<ChargesBatchYearDomain>();
+            _mockChargesBatchYearsGateway
+                .Setup(cby => cby.GetPendingYear())
+                .ReturnsAsync(chargesBatchYear);
+
+            var googleFileSettings = RandomGen.CreateMany<GoogleFileSettingDomain>(quantity: 1).ToList();
+            googleFileSettings[0].FileYear = chargesBatchYear.Year;
+            _mockGoogleFileSettingGateway
+                .Setup(gfs => gfs.GetSettingsByLabel(It.IsAny<string>()))
+                .ReturnsAsync(googleFileSettings);
+
+            // Make the retry policy merely be an empty wrapper around the callback.
+            _mockFetchSheetRetryPolicy
+                .Setup(
+                    p => p.ExecuteAsync(It.IsAny<FetchChargesSheet>())
+                )
+                .Returns(
+                    (FetchChargesSheet incFunc) => Task.FromResult(incFunc().Result)
+                );
+
+            var capturedInputs = new List<ReadGSheetInputsTuple>();
+            _mockGoogleClientService.Setup(
+                gc => gc.ReadSheetToEntitiesAsync<ChargesAuxDomain>(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                )
+            )
+            .Callback<string, string, string>((sheetId, sheetName, cellRange) => {
+                capturedInputs.Add((sheetId, sheetName, cellRange));
+            })
+            .ReturnsAsync(RandomGen.CreateMany<ChargesAuxDomain>().ToList());
+
+            // act
+            await _classUnderTest.ExecuteAsync();
+
+            // assert
+            foreach (var (sheetId, sheetName, cellRange) in capturedInputs)
+            {
+                var expectedRange = IsSheetTabLeasehold(sheetName)
+                    ? "A:AZ"
+                    : "A:AX";
+
+                Assert.AreEqual(sheetId, googleFileSettings.GoogleIdentifier);
+                Assert.IsTrue(sheetRentGroups.Contains(sheetName));
+                Assert.AreEqual(cellRange, expectedRange(sheetName));
+            }
+        }
+
+        private bool IsSheetTabLeasehold(string sheetRentGroup)
+        {
+            return sheetRentGroup == RentGroup.LHServCharges.ToString()
+                || sheetRentGroup == RentGroup.LHMajorWorks.ToString();
         }
     }
 }

--- a/HfsChargesContainer.Tests/UseCases/LoadChargesUseCaseTests.cs
+++ b/HfsChargesContainer.Tests/UseCases/LoadChargesUseCaseTests.cs
@@ -13,7 +13,7 @@ using Xunit;
 namespace HfsChargesContainer.Tests.UseCases
 {
     using FetchChargesSheet = Func<Task<IList<ChargesAuxDomain>>>;
-    using ReadGSheetInputsTuple = (string sheetId, string sheetName, string cellRange);
+    using ReadGSheetInputsTuple = ValueTuple<string, string, string>;
 
     public class LoadChargesUseCaseTests
     {


### PR DESCRIPTION
# What:
 - A test to test Load Charges UCs charges sheet cell range selection logic.

# Why:
 - New codes that get added to the charges sheet are leasehold codes. Meaning, leasehold sheet tabs and rent sheet tabs no longer have an equal amount of columns.

# Notes:
 - This logic is handled via private method, hence the testing is done indirectly by capturing the input parameters for Google Client Service's sheet read method.
 - The method being checked is called multiple times: once per sheet tab / rent group. So testing has to be done for each input combination.
 - This work was done on a separate branch using Web Editor as there wasn't enough time to set the development environment up since setting up the computer from scratch. Which is why this piece of work is a PR into another feature branch.