### PR TITLE
Add support for the new debit codes into the nightly charges load process.

### DIFF
--- a/HfsChargesContainer/Domain/ChargesAuxDomain.cs
+++ b/HfsChargesContainer/Domain/ChargesAuxDomain.cs
@@ -84,6 +84,12 @@ namespace HfsChargesContainer.Domain
         [JsonProperty("Major Works Revenue")]
         public decimal? DMR { get; set; }
 
+        [JsonProperty("Staff Costs")]
+        public decimal? DR1 { get; set; }
+
+        [JsonProperty("CCTV monitoring")]
+        public decimal? DR2 { get; set; }
+
         [JsonProperty("R Administration Fee")]
         public decimal? DR5 { get; set; }
 

--- a/HfsChargesContainer/Gateways/ChargesGateway.cs
+++ b/HfsChargesContainer/Gateways/ChargesGateway.cs
@@ -52,6 +52,8 @@ namespace HfsChargesContainer.Gateways
                     DMC = c.DMC ?? 0,
                     DMJ = c.DMJ ?? 0,
                     DMR = c.DMR ?? 0,
+                    DR1 = c.DR1 ?? 0,
+                    DR2 = c.DR2 ?? 0,
                     DR5 = c.DR5 ?? 0,
                     DRP = c.DRP ?? 0,
                     DRR = c.DRR ?? 0,

--- a/HfsChargesContainer/Infrastructure/ChargesAux.cs
+++ b/HfsChargesContainer/Infrastructure/ChargesAux.cs
@@ -36,6 +36,8 @@ namespace HfsChargesContainer.Infrastructure
         public decimal DMC { get; set; }
         public decimal DMJ { get; set; }
         public decimal DMR { get; set; }
+        public decimal DR1 { get; set; }
+        public decimal DR2 { get; set; }
         public decimal DR5 { get; set; }
         public decimal DRP { get; set; }
         public decimal DRR { get; set; }

--- a/HfsChargesContainer/UseCases/LoadChargesUseCase.cs
+++ b/HfsChargesContainer/UseCases/LoadChargesUseCase.cs
@@ -58,8 +58,8 @@ namespace HfsChargesContainer.UseCases
                     {
                         var fetchChargesCallback = GetChargesBySheetTabCB(
                             sheetId: googleFile.GoogleIdentifier,
-                            tabName: GetSheetRangeByRentGroup(sheetName),
-                            cellRange: sheetRange
+                            tabName: sheetName.ToString(),
+                            cellRange: GetSheetRangeByRentGroup(sheetName)
                         );
 
                         var chargesAux = await _fetchSheetRetryPolicy

--- a/HfsChargesContainer/UseCases/LoadChargesUseCase.cs
+++ b/HfsChargesContainer/UseCases/LoadChargesUseCase.cs
@@ -42,8 +42,6 @@ namespace HfsChargesContainer.UseCases
         {
             LoggingHandler.LogInfo($"Starting charges import");
 
-            const string sheetRange = "A:AX";
-
             var batch = await _batchLogGateway.CreateAsync(ChargesLabel).ConfigureAwait(false);
             var googleFileSettings = await GetGoogleFileSetting(ChargesLabel).ConfigureAwait(false);
 
@@ -56,11 +54,11 @@ namespace HfsChargesContainer.UseCases
             {
                 if (googleFile.FileYear == pendingYear.Year)
                 {
-                    foreach (var sheetName in Enum.GetValues(typeof(RentGroup)))
+                    foreach (RentGroup sheetName in Enum.GetValues(typeof(RentGroup)))
                     {
                         var fetchChargesCallback = GetChargesBySheetTabCB(
                             sheetId: googleFile.GoogleIdentifier,
-                            tabName: sheetName.ToString(),
+                            tabName: GetSheetRangeByRentGroup(sheetName),
                             cellRange: sheetRange
                         );
 
@@ -81,6 +79,14 @@ namespace HfsChargesContainer.UseCases
             await _batchLogGateway.SetToSuccessAsync(batch.Id).ConfigureAwait(false);
             LoggingHandler.LogInfo($"End charges import");
             return true;
+        }
+
+        private string GetSheetRangeByRentGroup(RentGroup sheetTabName)
+        {
+            const string sheetRangeRent = "A:AX";
+            const string sheetRangeLeasehold = "A:AZ";
+            const RentGroup[] leaseholdSheetNames = new[] { RentGroup.LHServCharges, RentGroup.LHMajorWorks };
+            return leaseholdSheetNames.Contains(sheetTabName) ? sheetRangeLeasehold : sheetRangeRent;
         }
 
         private FetchChargesBySheetTab GetChargesBySheetTabCB(string sheetId, string tabName, string cellRange)

--- a/HfsChargesContainer/UseCases/LoadChargesUseCase.cs
+++ b/HfsChargesContainer/UseCases/LoadChargesUseCase.cs
@@ -85,7 +85,7 @@ namespace HfsChargesContainer.UseCases
         {
             const string sheetRangeRent = "A:AX";
             const string sheetRangeLeasehold = "A:AZ";
-            const RentGroup[] leaseholdSheetNames = new[] { RentGroup.LHServCharges, RentGroup.LHMajorWorks };
+            RentGroup[] leaseholdSheetNames = new[] { RentGroup.LHServCharges, RentGroup.LHMajorWorks };
             return leaseholdSheetNames.Contains(sheetTabName) ? sheetRangeLeasehold : sheetRangeRent;
         }
 


### PR DESCRIPTION
# What:
 - Add support for the processing of DR1 and DR2 debit charge codes.
 - Make the charges sheet cell range conditional depending on whether it's a leasehold or rent rentgroup.

# Why:
 - Business recently requested Staff Costs and CCTV monitoring charges to be processable by the nightly charges process for the leasehold properties.

# Notes:
 - This work continues the work done within this PR: LBHackney-IT/HFSDatabaseObjects/pull/175.