### PR TITLE
Log failures happening within the retry policy wrapper.

### DIFF
--- a/HfsChargesContainer/Startup.cs
+++ b/HfsChargesContainer/Startup.cs
@@ -85,12 +85,6 @@ namespace HfsChargesContainer
             var asyncRetryPolicy = Policy<TOut>
                 .Handle<Exception>()
                 .WaitAndRetryAsync(
-                    Backoff.DecorrelatedJitterBackoffV2(
-                        medianFirstRetryDelay: TimeSpan.FromSeconds(5),
-                        retryCount: 10
-                    )
-                );
-                .WaitAndRetryAsync(
                     sleepDurations: Backoff.DecorrelatedJitterBackoffV2(
                         medianFirstRetryDelay: TimeSpan.FromSeconds(5),
                         retryCount: 10


### PR DESCRIPTION
# What:
 - Attempt at making Polly Retry policy to log the failures it encounters.

# Why:
 - Because it otherwise it takes 40+ minutes to get the results back duet to have to wait 10 exponential retries for the error to show up on 12th _(1+10+1)_ failure.
 - Added benefit _(if this works)_ will be that we'll log any temporary network failures that aren't getting detected now.
