### PR TITLE
Make the DR1 and DR2 codes also apply for the RENT rent group.

### DIFF
--- a/HfsChargesContainer.Tests/UseCases/LoadChargesUseCaseTests.cs
+++ b/HfsChargesContainer.Tests/UseCases/LoadChargesUseCaseTests.cs
@@ -201,9 +201,10 @@ namespace HfsChargesContainer.Tests.UseCases
             // assert
             foreach (var (sheetId, sheetName, cellRange) in capturedInputs)
             {
+                // These match circumstantially due to a requirement change.
                 var expectedRange = IsSheetTabLeasehold(sheetName)
                     ? "A:AZ"
-                    : "A:AX";
+                    : "A:AZ";
 
                 Assert.Equal(sheetId, googleFileSettings.First().GoogleIdentifier);
                 Assert.True(sheetRentGroups.Contains(sheetName));

--- a/HfsChargesContainer/UseCases/LoadChargesUseCase.cs
+++ b/HfsChargesContainer/UseCases/LoadChargesUseCase.cs
@@ -83,7 +83,8 @@ namespace HfsChargesContainer.UseCases
 
         private string GetSheetRangeByRentGroup(RentGroup sheetTabName)
         {
-            const string sheetRangeRent = "A:AX";
+            // Sheet ranges will match now after the new requirements, but they won't match in general.
+            const string sheetRangeRent = "A:AZ";
             const string sheetRangeLeasehold = "A:AZ";
             RentGroup[] leaseholdSheetNames = new[] { RentGroup.LHServCharges, RentGroup.LHMajorWorks };
             return leaseholdSheetNames.Contains(sheetTabName) ? sheetRangeLeasehold : sheetRangeRent;


### PR DESCRIPTION
# What:
 - Make repurposed DR1 and DR2 debit codes processable for RENT rent groups as well.

# Why:
 - Apparently, at least one of them is needed by the Housing Revenue rent group.