### PR TITLE
Removed Sunday-only processing

### DIFF
--- a/HfsChargesContainer.Tests/UseCases/CheckChargesBatchYearsUseCaseTests.cs
+++ b/HfsChargesContainer.Tests/UseCases/CheckChargesBatchYearsUseCaseTests.cs
@@ -53,7 +53,7 @@ namespace HfsChargesContainer.Tests.UseCases
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Test ignored to resume Sunday processing")]
         public async Task OnNonSundayOnlyLatestBatchYearGetProcessed()
         {
             // arrange

--- a/HfsChargesContainer/UseCases/CheckChargesBatchYearsUseCase.cs
+++ b/HfsChargesContainer/UseCases/CheckChargesBatchYearsUseCase.cs
@@ -25,10 +25,10 @@ namespace HfsChargesContainer.UseCases
             if (!existDate)
             {
                 var chargesBatchYears = _chargesBatchYears.Split(';').Select(int.Parse).ToList();
-                int maxYear = chargesBatchYears.Max();
+                //int maxYear = chargesBatchYears.Max();
 
-                if (DateTimeProvider.Now.DayOfWeek != DayOfWeek.Sunday)
-                    chargesBatchYears = chargesBatchYears.Where(year => year == maxYear).ToList();
+                //if (DateTimeProvider.Now.DayOfWeek != DayOfWeek.Sunday)
+                //    chargesBatchYears = chargesBatchYears.Where(year => year == maxYear).ToList();
 
                 foreach (var year in chargesBatchYears)
                 {

--- a/HfsChargesContainer/UseCases/CheckChargesBatchYearsUseCase.cs
+++ b/HfsChargesContainer/UseCases/CheckChargesBatchYearsUseCase.cs
@@ -25,11 +25,6 @@ namespace HfsChargesContainer.UseCases
             if (!existDate)
             {
                 var chargesBatchYears = _chargesBatchYears.Split(';').Select(int.Parse).ToList();
-                //int maxYear = chargesBatchYears.Max();
-
-                //if (DateTimeProvider.Now.DayOfWeek != DayOfWeek.Sunday)
-                //    chargesBatchYears = chargesBatchYears.Where(year => year == maxYear).ToList();
-
                 foreach (var year in chargesBatchYears)
                 {
                     await _chargesBatchYearsGateway.CreateAsync(year).ConfigureAwait(false);


### PR DESCRIPTION
We added Sunday-only processing so that the previous fiinancial years would only be processed on Sunday

This is a hot-fix to revert that change to remove that logic so that all batch-years are processed every night