### PR TITLE
Fix race condition between setting environment variables to testable values and simultaneous null'ing of overlapping environment variables.

### DIFF
--- a/HfsChargesContainer.Tests/Helpers/RuntimeEnvVarsHandlerTests.cs
+++ b/HfsChargesContainer.Tests/Helpers/RuntimeEnvVarsHandlerTests.cs
@@ -9,6 +9,7 @@ using HfsChargesContainer.Helpers;
 using HfsChargesContainer.Helpers.Interfaces;
 using Moq;
 using Xunit;
+using Xunit.Extensions.Ordering;
 
 namespace HfsChargesContainer.Tests.Helpers
 {

--- a/HfsChargesContainer.Tests/Helpers/RuntimeEnvVarsHandlerTests.cs
+++ b/HfsChargesContainer.Tests/Helpers/RuntimeEnvVarsHandlerTests.cs
@@ -57,6 +57,7 @@ namespace HfsChargesContainer.Tests.Helpers
         }
 
         [Fact]
+        [Repeat(100)]
         public void RuntimeEnvVarsHandlerSetsTheEnvironment()
         {
             // arrange

--- a/HfsChargesContainer.Tests/Helpers/RuntimeEnvVarsHandlerTests.cs
+++ b/HfsChargesContainer.Tests/Helpers/RuntimeEnvVarsHandlerTests.cs
@@ -13,7 +13,7 @@ using Xunit.Extensions.Ordering;
 
 namespace HfsChargesContainer.Tests.Helpers
 {
-    [Order(1)]
+    [Order(9001)]
     public class RuntimeEnvVarsHandlerTests
     {
         private Dictionary<string, string> _ssmToAppKeyLookup;

--- a/HfsChargesContainer.Tests/Helpers/RuntimeEnvVarsHandlerTests.cs
+++ b/HfsChargesContainer.Tests/Helpers/RuntimeEnvVarsHandlerTests.cs
@@ -58,7 +58,7 @@ namespace HfsChargesContainer.Tests.Helpers
 
         [Theory]
         [Repeat(100)]
-        public void RuntimeEnvVarsHandlerSetsTheEnvironment()
+        public void RuntimeEnvVarsHandlerSetsTheEnvironment(int _)
         {
             // arrange
             var appKeys = _ssmToAppKeyLookup.Values.ToList();

--- a/HfsChargesContainer.Tests/Helpers/RuntimeEnvVarsHandlerTests.cs
+++ b/HfsChargesContainer.Tests/Helpers/RuntimeEnvVarsHandlerTests.cs
@@ -12,6 +12,7 @@ using Xunit;
 
 namespace HfsChargesContainer.Tests.Helpers
 {
+    [Order(1)]
     public class RuntimeEnvVarsHandlerTests
     {
         private Dictionary<string, string> _ssmToAppKeyLookup;

--- a/HfsChargesContainer.Tests/Helpers/RuntimeEnvVarsHandlerTests.cs
+++ b/HfsChargesContainer.Tests/Helpers/RuntimeEnvVarsHandlerTests.cs
@@ -57,7 +57,7 @@ namespace HfsChargesContainer.Tests.Helpers
         }
 
         [Theory]
-        [Repeat(100)]
+        [Repeat(5000)]
         public void RuntimeEnvVarsHandlerSetsTheEnvironment(int _)
         {
             // arrange

--- a/HfsChargesContainer.Tests/Helpers/RuntimeEnvVarsHandlerTests.cs
+++ b/HfsChargesContainer.Tests/Helpers/RuntimeEnvVarsHandlerTests.cs
@@ -58,9 +58,8 @@ namespace HfsChargesContainer.Tests.Helpers
                 Times.Once);
         }
 
-        [Theory]
-        [Repeat(5000)]
-        public void RuntimeEnvVarsHandlerSetsTheEnvironment(int _)
+        [Fact]
+        public void RuntimeEnvVarsHandlerSetsTheEnvironment()
         {
             // arrange
             var appKeys = _ssmToAppKeyLookup.Values.ToList();

--- a/HfsChargesContainer.Tests/Helpers/RuntimeEnvVarsHandlerTests.cs
+++ b/HfsChargesContainer.Tests/Helpers/RuntimeEnvVarsHandlerTests.cs
@@ -56,7 +56,7 @@ namespace HfsChargesContainer.Tests.Helpers
                 Times.Once);
         }
 
-        [Fact]
+        [Theory]
         [Repeat(100)]
         public void RuntimeEnvVarsHandlerSetsTheEnvironment()
         {

--- a/HfsChargesContainer.Tests/HfsChargesContainer.Tests.csproj
+++ b/HfsChargesContainer.Tests/HfsChargesContainer.Tests.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="Polly" Version="8.3.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Xunit.Extensions.Ordering" Version="1.4.5" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/HfsChargesContainer.Tests/TestsHelpers/RepeatAttribute.cs
+++ b/HfsChargesContainer.Tests/TestsHelpers/RepeatAttribute.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit.Sdk;
+
+public class RepeatAttribute : DataAttribute
+{
+    private readonly int _count;
+
+    public RepeatAttribute(int count)
+    {
+        if (count < 1)
+        {
+            throw new System.ArgumentOutOfRangeException(nameof(count), "Repeat count must be greater than zero.");
+        }
+        _count = count;
+    }
+
+    public override IEnumerable<object[]> GetData(MethodInfo testMethod)
+    {
+        for (int i = 0; i < _count; i++)
+        {
+            yield return new object[0];
+        }
+    }
+}

--- a/HfsChargesContainer.Tests/TestsHelpers/RepeatAttribute.cs
+++ b/HfsChargesContainer.Tests/TestsHelpers/RepeatAttribute.cs
@@ -17,9 +17,9 @@ public class RepeatAttribute : DataAttribute
 
     public override IEnumerable<object[]> GetData(MethodInfo testMethod)
     {
-        for (int i = 0; i < _count; i++)
+        for (int i = 1; i <= _count; i++)
         {
-            yield return new object[0];
+            yield return new object[] { i };
         }
     }
 }

--- a/HfsChargesContainer.Tests/TestsHelpers/RepeatAttribute.cs
+++ b/HfsChargesContainer.Tests/TestsHelpers/RepeatAttribute.cs
@@ -2,6 +2,9 @@ using System.Collections.Generic;
 using System.Reflection;
 using Xunit.Sdk;
 
+/// 'Repeat' test attribute that is used to debug testss flake
+/// Usage: Mark your test method as [Theory] and add [Repeat(100)] below it.
+/// Then add a 'int _' input parameter to you test method signature.
 public class RepeatAttribute : DataAttribute
 {
     private readonly int _count;


### PR DESCRIPTION
# What:
 - Fixed a race condition between environment variable setter tests and the remaining tests that implicitly null certain env vars required by the setter assertions.
 - Added flaky test rerun attribute.

# Why:
 - Investigation into failing environment variable setter tests was done as certain failures were encountered that were not present before. To rule out the possibility of these failures being related to PR #26 or PR #24 changes, failing flaky tests were investigated in more detail. It turned out that the failure was race condition related. It's possible that the d8 upgrade simply made the race condition more likely than before. Meaning, the failures do not seem to be some d6-d8 compatibility related.

# Notes:
 - The fix to resolve the race condition was to install the xUnit extension that allows ordering test classes. These changes made the environment variable setter tests run last so that all the other tests that null env vars wouldn't interfere with tested global state.
 - The flaky test rerun attribute was kept despite not being used in code. That is because it was used before, and may need to be used going forward.