### PR TITLE
HT-925: Add graceful handling of spreadsheet errors

### DIFF
--- a/HfsChargesContainer.Tests/Gateways/GoogleClientServiceTests.cs
+++ b/HfsChargesContainer.Tests/Gateways/GoogleClientServiceTests.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Google.Apis.Http;
+using Google.Apis.Services;
+using Google.Apis.Sheets.v4;
+using Google.Apis.Sheets.v4.Data;
+using HfsChargesContainer.Gateways;
+using Moq;
+using Moq.Protected;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace HfsChargesContainer.Tests.Gateways
+{
+    public class GoogleClientServiceTests
+    {
+        [Fact]
+        public async Task ReadSheetToEntitiesAsyncShouldTrimSpacesAndSkipMalformedRows()
+        {
+            // Arrange
+            var spreadSheetId = "1234";
+            var sheetName = "Sheet1";
+            var range = "A1:B2";
+
+            IList<IList<object>> values = new List<IList<object>>
+            {
+                new List<object> { "Prop1", "Prop2" },
+                new List<object> { "  Value 1  ", "100" },
+                new List<object> { "Bad Row", "NotANumber" },
+                new List<object> { "Value 3", "200" }
+            };
+
+            var jsonResponse = JsonConvert.SerializeObject(new ValueRange { Values = values });
+
+            var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            mockHandler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(jsonResponse)
+                });
+
+            var mockHttpClientFactory = new Mock<IHttpClientFactory>();
+            mockHttpClientFactory.Setup(f => f.CreateHttpClient(It.IsAny<CreateHttpClientArgs>()))
+                .Returns(new ConfigurableHttpClient(new ConfigurableMessageHandler(mockHandler.Object)));
+
+            var initializer = new BaseClientService.Initializer
+            {
+                HttpClientFactory = mockHttpClientFactory.Object,
+                ApplicationName = "Test"
+            };
+
+            var sheetsService = new SheetsService(initializer);
+            var serviceUnderTest = new GoogleClientService(sheetsService);
+
+            // Act
+            var results = await serviceUnderTest
+                .ReadSheetToEntitiesAsync<TestSheetEntity>(spreadSheetId, sheetName, range)
+                .ConfigureAwait(false);
+
+            // Assert
+            results.Should().NotBeNull();
+            results.Should().HaveCount(2);
+            results[0].Prop1.Should().Be("Value 1");
+            results[0].Prop2.Should().Be(100);
+            results[1].Prop1.Should().Be("Value 3");
+            results[1].Prop2.Should().Be(200);
+        }
+
+        public class TestSheetEntity
+        {
+            public string Prop1 { get; set; }
+            public int Prop2 { get; set; }
+        }
+    }
+}

--- a/HfsChargesContainer/Gateways/GoogleClientService.cs
+++ b/HfsChargesContainer/Gateways/GoogleClientService.cs
@@ -73,11 +73,11 @@ namespace HfsChargesContainer.Gateways
                 var entities = new List<_TEntity>();
                 bool hasErrors = false;
 
-                foreach (var rowObject in rowObjects)
+                for (int i = 0; i < rowObjects.Count; i++)
                 {
                     try
                     {
-                        string convertedJson = JsonConvert.SerializeObject(rowObject);
+                        string convertedJson = JsonConvert.SerializeObject(rowObjects[i]);
                         var entity = JsonConvert.DeserializeObject<_TEntity>(convertedJson);
                         if (entity != null)
                         {
@@ -87,7 +87,8 @@ namespace HfsChargesContainer.Gateways
                     catch (Exception exc)
                     {
                         hasErrors = true;
-                        LoggingHandler.LogWarning($"Skip row: Failure parsing row. Message: {exc.Message}");
+                        int spreadsheetRowNumber = i + 2; // exclude header
+                        LoggingHandler.LogWarning($"Skip row: Failure parsing row {spreadsheetRowNumber}. Message: {exc.Message}");
                     }
                 }
 

--- a/HfsChargesContainer/Gateways/GoogleClientService.cs
+++ b/HfsChargesContainer/Gateways/GoogleClientService.cs
@@ -55,7 +55,12 @@ namespace HfsChargesContainer.Gateways
                             : header;
 
                         // Assign the value to this property
-                        rowItemAccessor[propertyName] = row[cellIterator++];
+                        var cellValue = row[cellIterator++];
+                        if (cellValue is string stringValue)
+                        {
+                            cellValue = stringValue.Trim();
+                        }
+                        rowItemAccessor[propertyName] = cellValue;
                     }
                 }
                 rowObjects.Add(rowItem);
@@ -65,14 +70,37 @@ namespace HfsChargesContainer.Gateways
             try
             {
                 LoggingHandler.LogInfo($"Writing values to objects and serializing");
-                string convertedJson = JsonConvert.SerializeObject(rowObjects);
-                var entities = JsonConvert.DeserializeObject<IList<_TEntity>>(convertedJson);
+                var entities = new List<_TEntity>();
+                bool hasErrors = false;
+
+                foreach (var rowObject in rowObjects)
+                {
+                    try
+                    {
+                        string convertedJson = JsonConvert.SerializeObject(rowObject);
+                        var entity = JsonConvert.DeserializeObject<_TEntity>(convertedJson);
+                        if (entity != null)
+                        {
+                            entities.Add(entity);
+                        }
+                    }
+                    catch (Exception exc)
+                    {
+                        hasErrors = true;
+                        LoggingHandler.LogWarning($"Skip row: Failure parsing row. Message: {exc.Message}");
+                    }
+                }
+
+                if (hasErrors)
+                {
+                    LoggingHandler.LogError("ALARM: Spreadsheet row parsing failed. Some rows were skipped.");
+                }
 
                 return entities;
             }
             catch (Exception exc)
             {
-                LoggingHandler.LogInfo($"Error writing values to objects and serializing");
+                LoggingHandler.LogInfo($"Failure writing values to objects and serializing");
                 LoggingHandler.LogInfo(exc.ToString());
 
                 throw;


### PR DESCRIPTION
**What is the problem we're trying to solve**

Overnight charges spreadsheet processing is on occasion failing due to minor data quality issues, such as leading or trailing spaces in cells. Additionally, if a single row failed to parse the entire import process would crash, preventing any valid data from being saved.
This follows along this [PR](https://github.com/LBHackney-IT/housing-finance-interim-api/pull/252), which introduced such checks for the other processes.

**What changes have we introduced**

- Modified GoogleClientService.cs to automatically .Trim() all string values read from spreadsheet cells.
- Refactored ReadSheetToEntitiesAsync to process rows individually. Malformed rows are now logged and skipped, allowing the rest of the spreadsheet to be imported successfully.
- Implemented a specific ALARM log message for skipped rows: ALARM: Spreadsheet row parsing failed. Some rows were skipped.
- Added GoogleClientServiceTests to cover trimming and skipping malformed rows.
- MAA protection: the new behaviour relies on log markers rather than process exceptions. The charges import can complete successfully while still surfacing data quality issues via logs, reducing unnecessary fatal alerts for dirty spreadsheet rows.

**Follow up actions after merging PR**

- Deploy to development 
- Add the CloudWatch infrastructure (separate PR) for the alarm in housing-finance-interim-api and deploy to development
 - Verify expected behaviour via manual triggering (as the process is broken in Dev).
- Keep monitoring alert emails and container logs to identify which spreadsheets have the most frequent data quality issues.